### PR TITLE
Bugfix/24 improve error messages in the gateway console to be easier understandable by coat rack users

### DIFF
--- a/spring-boot/proxy/src/main/java/eu/coatrack/proxy/metrics/MetricsTransmitter.java
+++ b/spring-boot/proxy/src/main/java/eu/coatrack/proxy/metrics/MetricsTransmitter.java
@@ -108,6 +108,10 @@ public class MetricsTransmitter implements GaugeWriter {
             Object idOfTransmittedMetric = restTemplate.postForObject(uriToTransmitMetric, metricToTransmit, Long.class);
             log.info("transmitted Metrics to admin: {} - response was metric ID {}", metricToTransmit.toString(), idOfTransmittedMetric);
 
+            if(metricToTransmit.getHttpResponseCode() == 503){
+                log.error("An unexpected error occurred when your CoatRack gateway contacted the central CoatRack portal in order to verify an API key that was sent by a client: Service is not unavailable/accessible, please check if the service is accessible and gateway config in https://coatrack.eu/admin/proxies");
+            }
+
             /*
             // create relationship from transmitted metric to this proxy
             addRelationshipFromMetricToOtherEntity(
@@ -128,7 +132,7 @@ public class MetricsTransmitter implements GaugeWriter {
             */
 
         } catch (Exception e) {
-            log.error("Exception when communicating with CoatRack admin server", e);
+            log.error("An unexpected error occurred when your CoatRack gateway contacted the central CoatRack portal in order to send the statistics/metrics from this call: please contact a CoatRack administrator to solve this issue", e);
         }
     }
 

--- a/spring-boot/proxy/src/main/resources/application.yml
+++ b/spring-boot/proxy/src/main/resources/application.yml
@@ -26,5 +26,5 @@ custom-metrics:
 
 logging:
   level:
-    eu.coatrack.proxy: DEBUG
-    org.springframework.security: DEBUG
+    eu.coatrack.proxy: INFO
+    org.springframework.security: INFO


### PR DESCRIPTION
- Added error message on Gateway console, in case the service is not accessible by the CoatRack gateway
- Changed error message when Gateway cannot send/transmit the metrics to CoatRack admin