### PR TITLE
Bugfix/36 gateway allows access to deleted api keys

### DIFF
--- a/spring-boot/admin/src/main/java/eu/coatrack/admin/controllers/AdminApiKeysController.java
+++ b/spring-boot/admin/src/main/java/eu/coatrack/admin/controllers/AdminApiKeysController.java
@@ -173,27 +173,6 @@ public class AdminApiKeysController {
                 user.setUsername(githubUser.get(0).getLogin());
                 user.setFirstname(githubUser.get(0).getName());
                 user.setEmail(githubUser.get(0).getEmail());
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
                 userRepository.save(user);
             }
 

--- a/spring-boot/proxy/src/main/java/eu/coatrack/proxy/security/ApiKeyAuthTokenVerifier.java
+++ b/spring-boot/proxy/src/main/java/eu/coatrack/proxy/security/ApiKeyAuthTokenVerifier.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -139,6 +140,9 @@ public class ApiKeyAuthTokenVerifier implements AuthenticationManager {
 
                 if (Date.valueOf(LocalDate.now()).after(apiKey.getValidUntil())) {
                     throw new CredentialsExpiredException("Api key is expired");
+                }
+                if (apiKey.getDeletedWhen() != null) {
+                    throw new AccessDeniedException("access denied");
                 }
                 return true;
             } else {

--- a/spring-boot/proxy/src/main/java/eu/coatrack/proxy/security/ApiKeyAuthTokenVerifier.java
+++ b/spring-boot/proxy/src/main/java/eu/coatrack/proxy/security/ApiKeyAuthTokenVerifier.java
@@ -142,7 +142,7 @@ public class ApiKeyAuthTokenVerifier implements AuthenticationManager {
                     throw new CredentialsExpiredException("Api key is expired");
                 }
                 if (apiKey.getDeletedWhen() != null) {
-                    throw new AccessDeniedException("access denied");
+                    return false;
                 }
                 return true;
             } else {


### PR DESCRIPTION
- Now when a call to the gateway is made with a deleted API key, it returns a 403 Forbidden.

closes #36 