### PR TITLE
Feature/#60-The-external/public-API-should-be-accessible-using-an-Oauth2-bearer-token

### DIFF
--- a/spring-boot/admin/src/main/java/eu/coatrack/admin/GitHubSecurityConfig.java
+++ b/spring-boot/admin/src/main/java/eu/coatrack/admin/GitHubSecurityConfig.java
@@ -20,13 +20,15 @@ package eu.coatrack.admin;
  * #L%
  */
 
+import eu.coatrack.admin.security.PublicApiTokenAccessFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,6 +39,10 @@ public class GitHubSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private static final String[] PERMITALL_RESOURCE_LIST = new String[]{"/catchPaymentResponse","/json/**", "/login", "/", "/403", "/registerUser", "/callback", "/fonts/**", "/webjars/**", "/robots.txt", "/assets/**", "/images/**"};
 
+    @Qualifier("userInfoTokenServices")
+    @Autowired
+    private ResourceServerTokenServices tokenServices;
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
@@ -45,17 +51,11 @@ public class GitHubSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(PERMITALL_RESOURCE_LIST).permitAll()
                 .anyRequest().authenticated()
                 .and()
+                .addFilterBefore(new PublicApiTokenAccessFilter(tokenServices), AbstractPreAuthenticatedProcessingFilter.class)
                 .logout().logoutUrl("/logout").logoutSuccessUrl("/").deleteCookies("XSRF-TOKEN", "auth_code", "JSESSIONID").invalidateHttpSession(true).clearAuthentication(true).permitAll()
                 .and()
                 //.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
                 .csrf().disable();
     }
-   
 
-    @Bean
-    @Primary
-    public ResourceServerProperties resource() {
-        return new ResourceServerProperties();
-    }
-    
 }

--- a/spring-boot/admin/src/main/java/eu/coatrack/admin/security/PublicApiTokenAccessFilter.java
+++ b/spring-boot/admin/src/main/java/eu/coatrack/admin/security/PublicApiTokenAccessFilter.java
@@ -1,0 +1,27 @@
+package eu.coatrack.admin.security;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+
+public class PublicApiTokenAccessFilter extends OAuth2AuthenticationProcessingFilter {
+
+    public PublicApiTokenAccessFilter(ResourceServerTokenServices resourceServerTokenServices) {
+
+        super();
+        setStateless(false);
+        setAuthenticationManager(oauthAuthenticationManager(resourceServerTokenServices));
+    }
+
+    private AuthenticationManager oauthAuthenticationManager(ResourceServerTokenServices tokenServices) {
+
+        OAuth2AuthenticationManager oauthAuthenticationManager = new OAuth2AuthenticationManager();
+
+        oauthAuthenticationManager.setResourceId("oauth2-resource");
+        oauthAuthenticationManager.setTokenServices(tokenServices);
+        oauthAuthenticationManager.setClientDetailsService(null);
+
+        return oauthAuthenticationManager;
+    }
+}


### PR DESCRIPTION
Now, the Oauth2.0 Bearer token can be used as authorization in CoatRack.

Closes #60 