### PR TITLE
closes #81

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,6 +3,7 @@ name: Java CI
 on:
   push:
     branches: [ master ]
+    tags-ignore: [ '**' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '[0-9].[0-9]+.[0-9]+'
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Maven Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('./**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build
+        run: bash build.sh
+
+      # extract the tag name from GITHUB_REF - e.g. refs/tags/1.0.0 --> 1.0.0
+      - name: Get Tag Name
+        id: get_tag_name
+        run: echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      # add proxy-${TAG_NAME}.jar to the release - assumes that TAG_NAME is equal to pom version
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: spring-boot/proxy/target/coatrack-proxy-${{ steps.get_tag_name.outputs.TAG_NAME }}.jar
+          asset_name: coatrack-proxy-${{ steps.get_tag_name.outputs.TAG_NAME }}.jar
+          asset_content_type: application/java-archive


### PR DESCRIPTION
Adds a new workflow `release.yml`, which will be triggered by pushing a new tag of the format `x.y.z`, where `x`,  `y`, and `z` are numbers.

The new workflow will create a new release with name `x.y.z` in GitHub under https://github.com/coatrack/coatrack/releases.
It will also add `spring-boot/proxy/target/coatrack-proxy-x.y.z.jar` as an additional asset to the release.

Example usage:

```
mvn versions:set -DnewVersion=1.7.0
git commit -a -m "update version to 1.7.0"
git push
git tag 1.7.0
git push --tags
```
The above would create a new release `1.7.0` and add an asset `coatrack-proxy-1.7.0.jar` available at <https://github.com/coatrack/coatrack/releases/download/1.7.0/coatrack-proxy-1.7.0.jar>.