### PR TITLE
Bugfix/#237 Solved metrics day inconsistency bug

### DIFF
--- a/spring-boot/admin/src/main/java/eu/coatrack/admin/YggAdminApplication.java
+++ b/spring-boot/admin/src/main/java/eu/coatrack/admin/YggAdminApplication.java
@@ -30,12 +30,21 @@ import org.springframework.web.client.RestTemplate;
 import org.thymeleaf.extras.java8time.dialect.Java8TimeDialect;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.time.ZoneId;
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableSwagger2
 @EnableJpaRepositories("eu.coatrack*")
 @ComponentScan(basePackages = {"eu.coatrack*", "eu.coatrack.*"})
 @EntityScan(basePackages = {"eu.coatrack*", "eu.coatrack.*"})
 public class YggAdminApplication {
+
+    // Quick fix of #237 by setting default time zones of Admin and Gateway to UCT timezone.
+    // In the future, this system should be overhauled by the introduction of ZonedDateTime's.
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("UTC")));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(YggAdminApplication.class, args);

--- a/spring-boot/proxy/src/main/java/eu/coatrack/proxy/metrics/MetricsCounterService.java
+++ b/spring-boot/proxy/src/main/java/eu/coatrack/proxy/metrics/MetricsCounterService.java
@@ -27,6 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.sql.Date;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.StringJoiner;
@@ -38,6 +40,11 @@ import eu.coatrack.api.ApiKey;
 @Service
 public class MetricsCounterService {
 
+    // Quick fix of #237 by setting default time zones of Admin and Gateway to UCT timezone.
+    // In the future, this system should be overhauled by the introduction of ZonedDateTime's.
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("Europe/London")));
+    }
     private static final Logger log = LoggerFactory.getLogger(MetricsCounterService.class);
 
     // this ID should be unique for each start of the proxy application, so that CoatRack admin knows when counting was restarted
@@ -51,9 +58,6 @@ public class MetricsCounterService {
     public MetricsCounterService(MeterRegistry meterRegistry, MetricsTransmitter metricsTransmitter) {
         this.meterRegistry = meterRegistry;
         this.metricsTransmitter = metricsTransmitter;
-        // Quick fix of #237 by setting default time zones of Admin and Gateway to UCT timezone.
-        // In the future, this system should be overhauled by the introduction of ZonedDateTime's.
-        TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of("Europe/London")));
     }
 
     public void increment(TemporaryMetricsAggregation tma) {
@@ -95,7 +99,7 @@ public class MetricsCounterService {
                 .add(tma.getApiKeyValue())
                 .add(tma.getMetricType().toString())
                 .add(String.valueOf(tma.getHttpResponseCode()))
-                .add(java.sql.Date.valueOf(utcTimeNow.toLocalDate()).toString())
+                .add(utcTimeNow.toLocalDate().toString())
                 .add(tma.getPath());
         return stringJoiner.toString();
     }

--- a/spring-boot/proxy/src/main/java/eu/coatrack/proxy/metrics/MetricsCounterService.java
+++ b/spring-boot/proxy/src/main/java/eu/coatrack/proxy/metrics/MetricsCounterService.java
@@ -113,7 +113,7 @@ public class MetricsCounterService {
         metricToTransmit.setRequestMethod(tma.getRequestMethod());
         metricToTransmit.setType(tma.getMetricType());
         metricToTransmit.setHttpResponseCode(tma.getHttpResponseCode());
-        metricToTransmit.setDateOfApiCall(java.util.Date.from(today.atStartOfDay().toInstant(ZoneOffset.UTC)));
+        metricToTransmit.setDateOfApiCall(Date.valueOf(today));
         metricToTransmit.setPath(tma.getPath());
         metricToTransmit.setMetricsCounterSessionID(counterSessionID);
 


### PR DESCRIPTION
Closes #237 

### Explanation of the Problem

I found the problem. The critical two lines are in the proxy module in the MetricsCounter class. One needs to know that there are two JDK classes Date:

    java.sql.date
    java.util.date

First critical snippet:
```java
.add(java.sql.Date.valueOf(LocalDate.now()).toString())
```
We use this snippet to generate a String like "2022-11-08" which remains the same for one day. This is necessary to build the same metric ID for two service requests that belong together. I just added java.sql. to make the difference clear between the two Date classes.

Second critical snippet:
```java
metricToTransmit.setDateOfApiCall(new java.util.Date());
```
We use java.util.date here, since it contains the time which is different for each request. We need this information to differentiate the two requests in the admin module.

### How to test this PR

The bug can be triggered by hand, when the time zone in `MetricsCounterService` class  is changed from "Europe/London" to a timezone in which it is still yesterday. For example, in Germany its currently 10:00 19th of January, while in "Pacific/Apia" it is 22:00. Now run set up CoatRack, e.g. via Docker Compose. If the Gateway sends data to the Web application, they should be visible in the Dashboard diagrams and the Report Table as if they arrived yesterday.

If you don't apply a timezone change and deploy CoatRack, the times should act normal.